### PR TITLE
Add missing import in runners/__init__.py

### DIFF
--- a/benchmark/runners/__init__.py
+++ b/benchmark/runners/__init__.py
@@ -6,10 +6,11 @@ Orchestrates benchmark execution, integrating OGhidra with ground truth
 and evaluation metrics.
 """
 
-from .benchmark_runner import BenchmarkRunner
+from .benchmark_runner import BenchmarkRunner, BenchmarkConfig
 from .oghidra_runner import OGhidraRunner
 
 __all__ = [
     "BenchmarkRunner",
+    "BenchmarkConfig",
     "OGhidraRunner",
 ]


### PR DESCRIPTION
Fixes an import error in `benchmark_cli` by exporting `BenchmarkConfig` from `benchmark_runners`.

`cli.py` imports `BenchmarkConfig` but `runners/__init__.py` did not export it which caused the import to fail.