### PR TITLE
Add GitHub Actions test workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  # Python dependencies declared in pyproject.toml and requirements.txt.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # Action versions used by the workflows in .github/workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.12"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.13"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
+
+      # Integration tests are deselected by the `-m "not integration"` default in
+      # pyproject.toml, since they need a live Ghidra + OGhidraMCP instance.
+      - name: Run unit tests
+        run: python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,17 @@ packages = ["src"]
 
 [tool.ruff]
 line-length = 128
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Integration tests need a live Ghidra + OGhidraMCP instance and/or a reachable
+# LLM endpoint, so they are deselected by default. Run them with `pytest -m integration`.
+addopts = ["-m", "not integration"]
+markers = [
+    "integration: requires a running Ghidra instance with the OGhidraMCP plugin and/or a reachable LLM endpoint",
+]
+filterwarnings = [
+    # A test that returns a value instead of asserting is reported as passing no
+    # matter what it returns. Treat it as an error so this cannot regress.
+    "error::pytest.PytestReturnNotNoneWarning",
+]

--- a/tests/test_read_bytes.py
+++ b/tests/test_read_bytes.py
@@ -11,11 +11,14 @@ Prerequisites:
 
 Usage:
     python tests/test_read_bytes.py
+    pytest -m integration tests/test_read_bytes.py
 """
 
+import base64
 import os
 import sys
-import warnings
+
+import pytest
 
 # Add project root to path for imports
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -24,12 +27,22 @@ sys.path.insert(0, project_root)
 from src.config import GhidraMCPConfig  # noqa: E402
 from src.ghidra_client import GhidraMCPClient  # noqa: E402
 
+# Every test in this module talks to a live GhidraMCP server, so none of them can
+# run in CI. They are deselected by the `-m "not integration"` default in
+# pyproject.toml and run explicitly with `pytest -m integration`.
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def require_ghidra_mcp_server():
+    """Skip rather than fail when there is no GhidraMCP server to talk to."""
+    config = GhidraMCPConfig()
+    if not GhidraMCPClient(config).health_check():
+        pytest.skip(f"No GhidraMCP server reachable at {config.base_url}")
+
 
 def test_read_bytes_hex_format():
     """Test reading bytes in hex dump format."""
-    warnings.warn(
-        "These tests only work if the Ghidra client is running with the MCP plugin working. Either the tests should be mocked or the tests are moved from pytest to some sort of system testing."
-    )
     print("\n" + "=" * 60)
     print("TEST: read_bytes (hex format)")
     print("=" * 60)
@@ -50,31 +63,24 @@ def test_read_bytes_hex_format():
     print("-" * 50)
 
     # Verify we got a response
-    if "Error" in result or "No program" in result:
-        print(f"\n[FAIL] Error reading bytes: {result}")
-        return False
+    assert "Error" not in result and "No program" not in result, f"Error reading bytes: {result}"
 
     # Check for expected bytes (function prologue)
     # 55 = PUSH RBP, 57 = PUSH RDI, 56 = PUSH RSI, 53 = PUSH RBX
     expected_start = "55 57 56 53"
     if expected_start.upper() in result.upper():
         print(f"\n[PASS] Found expected prologue bytes: {expected_start}")
-        return True
-    else:
-        print(f"\n[INFO] Did not find expected bytes '{expected_start}' - may be different binary")
-        print("[INFO] Checking if we got valid hex dump format...")
-        # Check if we at least got a valid hex dump format
-        if ":" in result and "|" in result:
-            print("[PASS] Valid hex dump format received")
-            return True
-        return False
+        return
+
+    # A different binary is fine, but the response must still be a valid hex dump.
+    print(f"\n[INFO] Did not find expected bytes '{expected_start}' - may be different binary")
+    print("[INFO] Checking if we got valid hex dump format...")
+    assert ":" in result and "|" in result, f"Response is not a valid hex dump: {result}"
+    print("[PASS] Valid hex dump format received")
 
 
 def test_read_bytes_raw_format():
     """Test reading bytes in base64 raw format."""
-    warnings.warn(
-        "These tests only work if the Ghidra client is running with the MCP plugin working. Either the tests should be mocked or the tests are moved from pytest to some sort of system testing."
-    )
     print("\n" + "=" * 60)
     print("TEST: read_bytes (raw/base64 format)")
     print("=" * 60)
@@ -92,28 +98,19 @@ def test_read_bytes_raw_format():
     print(result)
     print("-" * 50)
 
-    if "Error" in result or "No program" in result:
-        print(f"\n[FAIL] Error reading bytes: {result}")
-        return False
-
-    # Try to decode the base64
-    import base64
+    assert "Error" not in result and "No program" not in result, f"Error reading bytes: {result}"
 
     try:
         decoded = base64.b64decode(result)
-        print(f"\n[PASS] Successfully decoded {len(decoded)} bytes from base64")
-        print(f"Raw bytes (hex): {decoded.hex()}")
-        return True
     except Exception as e:
-        print(f"\n[FAIL] Could not decode base64: {e}")
-        return False
+        pytest.fail(f"Could not decode base64: {e}")
+
+    print(f"\n[PASS] Successfully decoded {len(decoded)} bytes from base64")
+    print(f"Raw bytes (hex): {decoded.hex()}")
 
 
 def test_read_bytes_multiple_addresses():
     """Test reading from multiple addresses in the function."""
-    warnings.warn(
-        "These tests only work if the Ghidra client is running with the MCP plugin working. Either the tests should be mocked or the tests are moved from pytest to some sort of system testing."
-    )
     print("\n" + "=" * 60)
     print("TEST: read_bytes from multiple function addresses")
     print("=" * 60)
@@ -129,27 +126,24 @@ def test_read_bytes_multiple_addresses():
         ("10040fb02", "JZ instruction"),
     ]
 
-    all_passed = True
+    failures = []
     for address, description in test_cases:
         print(f"\n--- {description} @ 0x{address} ---")
         result = client.read_bytes(address, length=8, format="hex")
 
         if "Error" in result or not result.strip():
             print(f"[FAIL] Could not read from 0x{address}")
-            all_passed = False
+            failures.append(f"0x{address} ({description}): {result.strip() or '(empty)'}")
         else:
             # Just show first line of hex dump
             first_line = result.split("\n")[0] if result else "(empty)"
             print(f"[OK] {first_line}")
 
-    return all_passed
+    assert not failures, "Could not read from:\n  " + "\n  ".join(failures)
 
 
 def test_read_bytes_boundary_conditions():
     """Test edge cases and boundary conditions."""
-    warnings.warn(
-        "These tests only work if the Ghidra client is running with the MCP plugin working. Either the tests should be mocked or the tests are moved from pytest to some sort of system testing."
-    )
     print("\n" + "=" * 60)
     print("TEST: read_bytes boundary conditions")
     print("=" * 60)
@@ -163,7 +157,7 @@ def test_read_bytes_boundary_conditions():
         ("10040fae0", 4096, "Maximum length (4096 bytes)"),
     ]
 
-    all_passed = True
+    failures = []
     for address, length, description in test_cases:
         print(f"\n--- {description} ---")
         result = client.read_bytes(address, length=length, format="hex")
@@ -173,17 +167,15 @@ def test_read_bytes_boundary_conditions():
                 print("[PASS] Correctly rejected length > 4096")
             else:
                 print(f"[FAIL] {result}")
-                all_passed = False
+                failures.append(f"{description}: {result.strip()}")
         else:
             lines = len(result.strip().split("\n"))
             expected_lines = (length + 15) // 16  # 16 bytes per line
             print(f"[OK] Got {lines} lines (expected ~{expected_lines})")
 
-    return all_passed
+    assert not failures, "Boundary checks failed:\n  " + "\n  ".join(failures)
 
 
-# TODO: These tests only work if the Ghidra client is running with the MCP plugin working.
-# Either the tests should be mocked or the tests are moved from pytest to some sort of system testing.
 def main():
     """Run all read_bytes tests."""
     print("\n" + "=" * 60)
@@ -207,12 +199,22 @@ def main():
     print(f"\n[OK] Connected to GhidraMCP at {config.base_url}")
 
     # Run tests
-    results = []
+    checks = [
+        ("Hex Format", test_read_bytes_hex_format),
+        ("Raw/Base64 Format", test_read_bytes_raw_format),
+        ("Multiple Addresses", test_read_bytes_multiple_addresses),
+        ("Boundary Conditions", test_read_bytes_boundary_conditions),
+    ]
 
-    results.append(("Hex Format", test_read_bytes_hex_format()))
-    results.append(("Raw/Base64 Format", test_read_bytes_raw_format()))
-    results.append(("Multiple Addresses", test_read_bytes_multiple_addresses()))
-    results.append(("Boundary Conditions", test_read_bytes_boundary_conditions()))
+    results = []
+    for name, check in checks:
+        try:
+            check()
+        except AssertionError as e:
+            print(f"\n[FAIL] {e}")
+            results.append((name, False))
+        else:
+            results.append((name, True))
 
     # Summary
     print("\n" + "=" * 60)


### PR DESCRIPTION
Towards #10, and addresses the Dependabot request in #36. Deliberately not
using closing keywords, since neither issue is fully resolved by this PR (see
"What is not covered" below).

## What this does

The repository currently has no `.github/` directory, so nothing runs on pull
requests except the pre-commit.ci hooks. This adds a test workflow, a Dependabot
config, and the pytest configuration needed to make the workflow meaningful.

### 1. `.github/workflows/ci.yml`

Runs `pytest` on pull requests and pushes to `main`, across Ubuntu, Windows and
macOS on Python 3.12, plus Python 3.13 on Ubuntu. Given the history of
platform-specific problems (#19, #44), a cross-OS matrix seemed worth the runner
minutes. `fail-fast` is off so one platform failing still reports the others.

I deliberately did **not** add a lint job. Ruff and shellcheck already run via
pre-commit.ci on every PR, and duplicating them here would just be a second red
X for the same problem.

### 2. `.github/dependabot.yml`

Weekly updates for `pip` and `github-actions`, with minor and patch bumps grouped
into a single PR per ecosystem to keep the noise down.

I left out the `gradle` ecosystem on purpose. `OGhidraMCP/build.gradle` declares
no resolvable dependencies of its own; everything comes from
`support/buildExtension.gradle` in the local Ghidra install. Dependabot would
have nothing to act on.

### 3. Test configuration and `tests/test_read_bytes.py`

This is the part that makes the workflow honest, and it fixes a real problem.

The four tests in `tests/test_read_bytes.py` talk to a live GhidraMCP server on
`127.0.0.1:8080`. When no server is running they take the error branch and
`return False`. Because a pytest test that *returns* a value rather than
asserting is reported as **passing** regardless of the value, these four tests
report green on any machine without Ghidra running. They have effectively never
verified anything in an automated context. There is already a `warnings.warn`
and a `# TODO` in that file noting the tests only work against a live plugin.

Changes:

- Converted the four tests from returning booleans to asserting, so a real
  failure is now a real failure.
- Marked the module `pytest.mark.integration`, and added
  `addopts = ["-m", "not integration"]` to `pyproject.toml` so integration tests
  are deselected by default and run with `pytest -m integration`.
- Added an autouse fixture that **skips** (rather than fails) when no GhidraMCP
  server is reachable, so an explicit `-m integration` run on a machine without
  Ghidra reports skipped instead of a misleading pass or a spurious failure.
- Added `filterwarnings = ["error::pytest.PytestReturnNotNoneWarning"]` so a
  return-instead-of-assert test becomes a hard error and this cannot regress.
- Rewrote `main()` to call the checks through `try/except AssertionError`, so
  `python tests/test_read_bytes.py` still works exactly as documented in the
  module docstring.

## What is not covered

Issue #10 names two hard parts: standing up Ghidra with the plugin, and running
an LLM in CI. This PR does neither. It covers the tests that need neither, and
puts a marker in place so the integration suite has somewhere to live once
@nightlark's [runner LLM inference
experiment](https://github.com/nightlark/actions-llm-inference-test/actions)
concludes. I did not want to pre-empt that work.

## Verification

Run locally on Python 3.12 and 3.13:

| Check | Result |
|---|---|
| `pytest` (what CI runs) | 106 passed, 4 deselected |
| `pytest -m integration` with no server | 4 skipped, 106 deselected |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 90 files already formatted |
| `pre-commit run` on changed files | all hooks passed |

Confirmed that a test written as `def test_x(): return False` now fails under
the new configuration instead of silently passing.

Happy to split this into separate PRs for the workflow, Dependabot, and the test
fix if you would rather review them independently. Also glad to sign whatever is
needed on the licensing side given the BSD-3 / commercial dual license, if there
is a process for outside contributors.
